### PR TITLE
Add vertical WHAT label to spec grid

### DIFF
--- a/PASpec.html
+++ b/PASpec.html
@@ -46,6 +46,16 @@
       border: 2px solid black;
       padding: 10px;
       margin-bottom: 20px;
+      position: relative;
+    }
+
+    .vertical-label {
+      position: absolute;
+      left: -40px;
+      top: 50%;
+      transform: translateY(-50%);
+      writing-mode: vertical-rl;
+      font-weight: bold;
     }
     .spec-grid {
       display: grid;
@@ -126,6 +136,7 @@
 
 
     <div class="spec-section">
+      <div class="vertical-label">WHAT</div>
       <div class="spec-grid">
         <div class="label-cell">What specific object(s) has the deviation?</div>
         <div class="drop-box"></div>


### PR DESCRIPTION
## Summary
- make spec section container relative
- add `vertical-label` style for rotated text
- insert a vertical "WHAT" label in the first spec grid

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6851d0c036fc832e9e60d4225cf2daf7