### PR TITLE
Adjust notes panel size and standardize color

### DIFF
--- a/PASpec.html
+++ b/PASpec.html
@@ -66,7 +66,7 @@
       text-align: center;
       padding: 10px;
     }
-    .is-box { background-color: red; color: white; }
+    .is-box { background-color: #E03C31; color: white; }
     .isnot-box { background-color: blue; color: white; }
     .label-cell {
       background-color: #eee;
@@ -106,7 +106,7 @@
         border: 2px dashed #ccc;
         border-radius: 10px;
         cursor: move;
-        width: 40vw;
+        width: 25vw;
         resize: both;
         overflow: auto;
       }
@@ -115,7 +115,7 @@
       flex-wrap: wrap;
       gap: 10px;
     }
-    .note-red { color: red; }
+    .note-red { color: #E03C31; }
     .note-blue { color: blue; }
   </style>
 </head>


### PR DESCRIPTION
## Summary
- shrink the notes panel so it doesn't dominate the page
- replace hard-coded red with KT red

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6851e082b28c832e915d7175bd920a57