### PR TITLE
Adjust notes panel and update colors

### DIFF
--- a/PASpec.html
+++ b/PASpec.html
@@ -66,8 +66,8 @@
       text-align: center;
       padding: 10px;
     }
-    .is-box { background-color: #E03C31; color: white; }
-    .isnot-box { background-color: blue; color: white; }
+    .is-box { background-color: #C0231B; color: white; }
+    .isnot-box { background-color: #0057b7; color: white; }
     .label-cell {
       background-color: #eee;
       padding: 10px;
@@ -109,14 +109,15 @@
         width: 25vw;
         resize: both;
         overflow: auto;
+        max-height: calc(100vh - 64px);
       }
     .notes-grid {
       display: flex;
       flex-wrap: wrap;
       gap: 10px;
     }
-    .note-red { color: #E03C31; }
-    .note-blue { color: blue; }
+    .note-red { color: #C0231B; }
+    .note-blue { color: #0057b7; }
   </style>
 </head>
 <body>


### PR DESCRIPTION
## Summary
- tweak notes panel to fit within the viewport
- set IS header to the proper red and standardize note colors
- use #0057b7 for all blues

## Testing
- `git show --stat`


------
https://chatgpt.com/codex/tasks/task_e_6851e4012ea0832eb03017abfff04a1d